### PR TITLE
Move blog post composition into route constructor

### DIFF
--- a/.idea/bradyanderson.tech-next.iml
+++ b/.idea/bradyanderson.tech-next.iml
@@ -6,6 +6,7 @@
       <excludeFolder url="file://$MODULE_DIR$/.tmp" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/public/code" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/src/blog/blog-components/page-templates/BlogPost.tsx
+++ b/src/blog/blog-components/page-templates/BlogPost.tsx
@@ -3,10 +3,10 @@ import moment from "moment";
 import PageHelmut from "./template-components/PageHelmut";
 import { scrollToTop } from "./templateUtils";
 import PostHeadNavigator from "../navigation/PostHeadNavigator";
-import { BlogPostProps } from "../../../../types/Sitemap";
+import { BlogPostWrapperProps } from "../../../../types/Sitemap";
 
 /** Blog post template. */
-const BlogPost: React.FunctionComponent<BlogPostProps> = ({
+const BlogPost: React.FunctionComponent<BlogPostWrapperProps> = ({
   title,
   categoryTitle,
   categoryBaseName,

--- a/src/blog/blog-components/page-templates/BlogPost.tsx
+++ b/src/blog/blog-components/page-templates/BlogPost.tsx
@@ -3,10 +3,10 @@ import moment from "moment";
 import PageHelmut from "./template-components/PageHelmut";
 import { scrollToTop } from "./templateUtils";
 import PostHeadNavigator from "../navigation/PostHeadNavigator";
-import { BlogPostWrapperProps } from "../../../../types/Sitemap";
+import { BlogPostTemplateProps } from "../../../../types/Sitemap";
 
 /** Blog post template. */
-const BlogPost: React.FunctionComponent<BlogPostWrapperProps> = ({
+const BlogPost: React.FunctionComponent<BlogPostTemplateProps> = ({
   title,
   categoryTitle,
   categoryBaseName,

--- a/src/blog/categories/retro-computing/posts/BootingASE30Post.tsx
+++ b/src/blog/categories/retro-computing/posts/BootingASE30Post.tsx
@@ -1,14 +1,13 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import Image from "../../../blog-components/Image";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import ExternalLink from "../../../blog-components/ExternalLink";
 import Paragraph from "../../../blog-components/Paragraph";
 
-function BootingASE30Post(props: BlogPostProps) {
+function BootingASE30Post({ BlogPost }: BlogPostProps) {
   const imageDirectory =
     "/blog/categories/retro-computing/posts/booting-an-se30";
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         In my last post, I wrote about how I discovered my Macintosh SE/30
         didn't have a hard drive. This explained why the computer didn't boot to

--- a/src/blog/categories/retro-computing/posts/FixingFloppyDrive.tsx
+++ b/src/blog/categories/retro-computing/posts/FixingFloppyDrive.tsx
@@ -1,14 +1,13 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import Paragraph from "../../../blog-components/Paragraph";
 import Image from "../../../blog-components/Image";
 import EmbeddedYouTubeVideo from "../../../blog-components/EmbeddedYouTubeVideo";
 
-function FixingFloppyDrive(props: BlogPostProps) {
+function FixingFloppyDrive({ BlogPost }: BlogPostProps) {
   const baseImagePath =
     "/blog/categories/retro-computing/posts/floppy-drive-fix";
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         After retrobrighting my Macintosh SE/30’s case, I reinstalled all the
         internal components back into the case. I spent some time testing some

--- a/src/blog/categories/retro-computing/posts/FixingKeyboardPost.tsx
+++ b/src/blog/categories/retro-computing/posts/FixingKeyboardPost.tsx
@@ -1,4 +1,3 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import Image from "../../../blog-components/Image";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import Paragraph from "../../../blog-components/Paragraph";
@@ -6,9 +5,9 @@ import Paragraph from "../../../blog-components/Paragraph";
 const imageBasePath =
   "/blog/categories/retro-computing/posts/se30-keyboard-fix";
 
-function FixingKeyboardPost(props: BlogPostProps) {
+function FixingKeyboardPost({ BlogPost }: BlogPostProps) {
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         When trying to solve a problem, I can sometimes fail to see the simple
         solution right in front of me. This time, however, I'm glad to admit

--- a/src/blog/categories/retro-computing/posts/FixingSE30SoundStruggle.tsx
+++ b/src/blog/categories/retro-computing/posts/FixingSE30SoundStruggle.tsx
@@ -1,14 +1,13 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import ExternalLink from "../../../blog-components/ExternalLink";
 import Image from "../../../blog-components/Image";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import Paragraph from "../../../blog-components/Paragraph";
 
-function FixingSE30SoundStruggle(props: BlogPostProps) {
+function FixingSE30SoundStruggle({ BlogPost }: BlogPostProps) {
   const imageBasePath =
     "/blog/categories/retro-computing/posts/fixing-macintosh-se30-sound-struggle";
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         I often tell people I'm a software engineer because I'm too clumsy to
         work with real things. Writing code feels natural, but I struggle to

--- a/src/blog/categories/retro-computing/posts/InstallingSCSI2SDPost.tsx
+++ b/src/blog/categories/retro-computing/posts/InstallingSCSI2SDPost.tsx
@@ -1,15 +1,14 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import ExternalLink from "../../../blog-components/ExternalLink";
 import EmbeddedYouTubeVideo from "../../../blog-components/EmbeddedYouTubeVideo";
 import Image from "../../../blog-components/Image";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import Paragraph from "../../../blog-components/Paragraph";
 
-function InstallingSCSI2SDPost(props: BlogPostProps) {
+function InstallingSCSI2SDPost({ BlogPost }: BlogPostProps) {
   const imageBasePath =
     "/blog/categories/retro-computing/posts/installing-scsi2sd-se30";
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         My Macintosh SE/30 did not come with a hard drive when I bought it. All
         SE/30s originally came with a hard drive, so it seems like the one in my

--- a/src/blog/categories/retro-computing/posts/OpeningAMacSE30Post.tsx
+++ b/src/blog/categories/retro-computing/posts/OpeningAMacSE30Post.tsx
@@ -1,15 +1,14 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import Image from "../../../blog-components/Image";
-import { BlogPostProps } from "../../../../../types/Sitemap";
 import ExternalLink from "../../../blog-components/ExternalLink";
 import Paragraph from "../../../blog-components/Paragraph";
+import { BlogPostProps } from "../../../../../types/Sitemap";
 
-function OpeningAMacSE30Post(props: BlogPostProps) {
+function OpeningAMacSE30Post({ BlogPost }: BlogPostProps) {
   const imageBasePath =
     "/blog/categories/retro-computing/posts/opening-a-mac-se-30";
 
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         On June 13th, I saw a Macintosh SE/30 at an antique store by my
         apartment. I've always wanted a retro Apple computer, but I knew almost

--- a/src/blog/categories/retro-computing/posts/SE30FTPConnectionPost.tsx
+++ b/src/blog/categories/retro-computing/posts/SE30FTPConnectionPost.tsx
@@ -1,13 +1,12 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import Image from "../../../blog-components/Image";
 import Paragraph from "../../../blog-components/Paragraph";
 import ExternalLink from "../../../blog-components/ExternalLink";
 
-function SE30FTPConnectionPost(props: BlogPostProps) {
+function SE30FTPConnectionPost({ BlogPost }: BlogPostProps) {
   const imageBasePath = `/blog/categories/retro-computing/posts/se30-ftp-connection`;
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Image
         path={`${imageBasePath}/ExpansionCard.jpg`}
         maxWidth="16rem"

--- a/src/blog/categories/retro-computing/posts/WhiteningAMacintoshPost.tsx
+++ b/src/blog/categories/retro-computing/posts/WhiteningAMacintoshPost.tsx
@@ -1,14 +1,13 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import Image from "../../../blog-components/Image";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import Paragraph from "../../../blog-components/Paragraph";
 
-function WhiteningAMacintoshPost(props: BlogPostProps) {
+function WhiteningAMacintoshPost({ BlogPost }: BlogPostProps) {
   const baseImagePath = `/blog/categories/retro-computing/posts/whitening-a-macintosh`;
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         When exposed to UV light, the plastic on some older electronics will
         turn yellow over time. The discoloration on doesn’t affect the

--- a/src/blog/categories/retro-gaming/posts/GameGearRepairPart1.tsx
+++ b/src/blog/categories/retro-gaming/posts/GameGearRepairPart1.tsx
@@ -1,14 +1,13 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import Paragraph from "../../../blog-components/Paragraph";
 import Image from "../../../blog-components/Image";
 import EmbeddedYouTubeVideo from "../../../blog-components/EmbeddedYouTubeVideo";
 import { Link } from "react-router-dom";
 
-function GameGearRepairPart1(props: BlogPostProps) {
+function GameGearRepairPart1({ BlogPost }: BlogPostProps) {
   const baseImagePath = "/blog/categories/retro-gaming/game-gear-repair-part-1";
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         The Sega Game Gear came out in 1990, less than 2 years after the
         Nintendo Game Boy. Unlike the Game Boy, though, the Game Gear has a

--- a/src/blog/categories/retro-gaming/posts/GameGearRepairPart2.tsx
+++ b/src/blog/categories/retro-gaming/posts/GameGearRepairPart2.tsx
@@ -1,4 +1,3 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import Paragraph from "../../../blog-components/Paragraph";
 import Image from "../../../blog-components/Image";
@@ -6,10 +5,10 @@ import EmbeddedYouTubeVideo from "../../../blog-components/EmbeddedYouTubeVideo"
 import { Link } from "react-router-dom";
 import ExternalLink from "../../../blog-components/ExternalLink";
 
-function GameGearRepairPart2(props: BlogPostProps) {
+function GameGearRepairPart2({ BlogPost }: BlogPostProps) {
   const baseImagePath = "/blog/categories/retro-gaming/game-gear-repair-part-2";
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         In <Link to={"game-gear-repair-part-1"}>part 1</Link>, I started my
         repair of a broken Game Gear by disassembling it and cleaning corrosion

--- a/src/blog/categories/retro-gaming/posts/GameGearRepairPart3.tsx
+++ b/src/blog/categories/retro-gaming/posts/GameGearRepairPart3.tsx
@@ -1,14 +1,13 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import Paragraph from "../../../blog-components/Paragraph";
 import Image from "../../../blog-components/Image";
 import EmbeddedYouTubeVideo from "../../../blog-components/EmbeddedYouTubeVideo";
 import { Link } from "react-router-dom";
 
-function GameGearRepairPart3(props: BlogPostProps) {
+function GameGearRepairPart3({ BlogPost }: BlogPostProps) {
   const baseImagePath = "/blog/categories/retro-gaming/game-gear-repair-part-3";
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         In <Link to={"game-gear-repair-part-2"}>part 2</Link>, I replaced the
         capacitors on the power PCB of my Game Gear and one capacitor (C68) on

--- a/src/blog/categories/retro-gaming/posts/ReplacingGameBoyColorSpeakerPost.tsx
+++ b/src/blog/categories/retro-gaming/posts/ReplacingGameBoyColorSpeakerPost.tsx
@@ -1,14 +1,13 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import EmbeddedYouTubeVideo from "../../../blog-components/EmbeddedYouTubeVideo";
 import Image from "../../../blog-components/Image";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import Paragraph from "../../../blog-components/Paragraph";
 
-function ReplacingGameBoyColorSpeakerPost(props: BlogPostProps) {
+function ReplacingGameBoyColorSpeakerPost({ BlogPost }: BlogPostProps) {
   const imageBasePath =
     "/blog/categories/retro-gaming/replacing-game-boy-color-speaker";
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         A few years ago, I got a Game Boy Color. Unfortunately, the speaker
         never worked. However, The headphone jack worked, so I wasn't too

--- a/src/blog/categories/website-updates/posts/BlogNavigationUpdates.tsx
+++ b/src/blog/categories/website-updates/posts/BlogNavigationUpdates.tsx
@@ -1,13 +1,12 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import Paragraph from "../../../blog-components/Paragraph";
 import Image from "../../../blog-components/Image";
 
-function BlogNavigationUpdates(props: BlogPostProps) {
+function BlogNavigationUpdates({ BlogPost }: BlogPostProps) {
   const baseImagePath =
     "/blog/categories/website-updates/posts/blog-navigation-updates";
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         When I launched this blog, I created a sidebar to allow for quick
         navigation between posts. This worked pretty well, but it had a few

--- a/src/blog/categories/website-updates/posts/CustomHoverDomainForHerokuAppPost.tsx
+++ b/src/blog/categories/website-updates/posts/CustomHoverDomainForHerokuAppPost.tsx
@@ -1,12 +1,11 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import Image from "../../../blog-components/Image";
 import ExternalLink from "../../../blog-components/ExternalLink";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import Paragraph from "../../../blog-components/Paragraph";
 
-function CustomHoverDomainForHerokuAppPost(props: BlogPostProps) {
+function CustomHoverDomainForHerokuAppPost({ BlogPost }: BlogPostProps) {
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         When you create an application in{" "}
         <ExternalLink link="https://www.heroku.com/">Heroku</ExternalLink>, you

--- a/src/blog/categories/website-updates/posts/EasilySettingCustomTitlePost.tsx
+++ b/src/blog/categories/website-updates/posts/EasilySettingCustomTitlePost.tsx
@@ -1,16 +1,15 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import Paragraph from "../../../blog-components/Paragraph";
 import Image from "../../../blog-components/Image";
 import ExternalLink from "../../../blog-components/ExternalLink";
 import Code from "../../../blog-components/Code";
 
-function EasilySettingCustomTitlePost(props: BlogPostProps) {
+function EasilySettingCustomTitlePost({ BlogPost }: BlogPostProps) {
   const baseAssetPath =
     "/blog/categories/bradyanderson-tech/posts/dynamically-updating-html-title";
 
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         On this website, I use{" "}
         <ExternalLink link="https://github.com/facebook/react">

--- a/src/blog/categories/website-updates/posts/GettingStartedPost.tsx
+++ b/src/blog/categories/website-updates/posts/GettingStartedPost.tsx
@@ -1,12 +1,11 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import Image from "../../../blog-components/Image";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import ExternalLink from "../../../blog-components/ExternalLink";
 import Paragraph from "../../../blog-components/Paragraph";
 
-function GettingStartedPost(props: BlogPostProps) {
+function GettingStartedPost({ BlogPost }: BlogPostProps) {
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Image
         path="/blog/categories/bradyanderson-tech/posts/getting-started/homepage.png"
         caption="The homepage on 07/25/2021."

--- a/src/blog/categories/website-updates/posts/MovingToAwsPost.tsx
+++ b/src/blog/categories/website-updates/posts/MovingToAwsPost.tsx
@@ -1,11 +1,10 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import ExternalLink from "../../../blog-components/ExternalLink";
 import Paragraph from "../../../blog-components/Paragraph";
 
-function MovingToAwsPost(props: BlogPostProps) {
+function MovingToAwsPost({ BlogPost }: BlogPostProps) {
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         Well, that didn't last long... I was planning some upcoming posts for
         this blog and I realized that I'm going to need ample space to post

--- a/src/blog/categories/website-updates/posts/SettingUpImageStoragePost.tsx
+++ b/src/blog/categories/website-updates/posts/SettingUpImageStoragePost.tsx
@@ -1,12 +1,11 @@
-import BlogPost from "../../../blog-components/page-templates/BlogPost";
 import Image from "../../../blog-components/Image";
 import { BlogPostProps } from "../../../../../types/Sitemap";
 import ExternalLink from "../../../blog-components/ExternalLink";
 import Paragraph from "../../../blog-components/Paragraph";
 
-function SettingUpImageStoragePost(props: BlogPostProps) {
+function SettingUpImageStoragePost({ BlogPost }: BlogPostProps) {
   return (
-    <BlogPost {...props}>
+    <BlogPost>
       <Paragraph>
         I want to post a lot of images on this blog, but my current setup won't
         make that easy. Right now, I'm storing all images in my Git repository.

--- a/src/blog/router/routeConstructor.tsx
+++ b/src/blog/router/routeConstructor.tsx
@@ -2,6 +2,8 @@ import { BlogCategoryRoutes, BlogPostRoutes } from "../../../types/Sitemap";
 import * as path from "path";
 import { join } from "path";
 import { Route, Switch } from "react-router-dom";
+import BlogPost from "../blog-components/page-templates/BlogPost";
+import { FunctionComponent } from "react";
 
 /**
  * Creates routing for blog categories.
@@ -49,14 +51,20 @@ function getPostRoutes(
     const { Component: PostComponent, title, date } = routes[postBaseName];
     const categoryBaseName = path.basename(categoryPath);
     const pathName = join(categoryPath, postBaseName);
+    const BlogPostWrapper: FunctionComponent = ({ children }) => (
+      <BlogPost
+        title={title}
+        date={date}
+        categoryTitle={categoryTitle}
+        categoryBaseName={categoryBaseName}
+      >
+        {children}
+      </BlogPost>
+    );
+
     return (
       <Route path={pathName} key={postBaseName}>
-        <PostComponent
-          title={title}
-          date={date}
-          categoryTitle={categoryTitle}
-          categoryBaseName={categoryBaseName}
-        />
+        <PostComponent BlogPost={BlogPostWrapper} />
       </Route>
     );
   });

--- a/types/Sitemap.ts
+++ b/types/Sitemap.ts
@@ -21,8 +21,8 @@ export interface BlogPostProps {
   BlogPost: FunctionComponent;
 }
 
-/** Props for Blog Wrapper Posts */
-export interface BlogPostWrapperProps extends BlogComponentProps {
+/** Props for Blog Post Template */
+export interface BlogPostTemplateProps extends BlogComponentProps {
   date: moment.Moment;
   categoryTitle: string;
   categoryBaseName: string;

--- a/types/Sitemap.ts
+++ b/types/Sitemap.ts
@@ -1,4 +1,5 @@
 import moment from "moment";
+import { FunctionComponent } from "react";
 
 /** Props for all components in blog map */
 export interface BlogComponentProps {
@@ -16,7 +17,12 @@ export interface BlogCategoryProps extends BlogComponentProps {
 }
 
 /** Props for Blog Posts */
-export interface BlogPostProps extends BlogComponentProps {
+export interface BlogPostProps {
+  BlogPost: FunctionComponent;
+}
+
+/** Props for Blog Wrapper Posts */
+export interface BlogPostWrapperProps extends BlogComponentProps {
   date: moment.Moment;
   categoryTitle: string;
   categoryBaseName: string;


### PR DESCRIPTION
Moves blog post composition into route constructor. This allows me to not have to pass props through every blog post.